### PR TITLE
Enhance batch assignment functionality and permissions

### DIFF
--- a/app/Actions/Batch/AssignBatchAction.php
+++ b/app/Actions/Batch/AssignBatchAction.php
@@ -2,13 +2,27 @@
 
 namespace App\Actions\Batch;
 
+use App\Enums\BatchStatus;
+use App\Enums\UserRole;
 use App\Models\Batch;
 use App\Models\FormSubmission;
+use App\Models\User;
+use InvalidArgumentException;
 
 class AssignBatchAction
 {
-    public function execute(FormSubmission $formSubmission, Batch $batch): void
+    public function execute(FormSubmission $formSubmission, Batch $batch, ?User $actor = null): void
     {
+        if ($batch->office_id !== $formSubmission->office_id) {
+            throw new InvalidArgumentException('The batch must belong to the same office as the submission.');
+        }
+
+        $actor ??= auth()->user();
+
+        if ($actor?->role !== UserRole::ADMIN->value && $batch->status === BatchStatus::FINALIZED) {
+            throw new InvalidArgumentException('Cannot assign to a finalized batch.');
+        }
+
         $formSubmission->update(['batch_id' => $batch->id]);
     }
 }

--- a/app/Actions/Batch/RevertBatchToPendingAction.php
+++ b/app/Actions/Batch/RevertBatchToPendingAction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions\Batch;
+
+use App\Enums\BatchStatus;
+use App\Models\Batch;
+use InvalidArgumentException;
+
+class RevertBatchToPendingAction
+{
+    /**
+     * Revert a finalized batch to pending so the representative can edit it again.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function execute(Batch $batch): void
+    {
+        if ($batch->status !== BatchStatus::FINALIZED) {
+            throw new InvalidArgumentException('Only finalized batches can be reverted to pending.');
+        }
+
+        $batch->update([
+            'status' => BatchStatus::PENDING->value,
+            'application_status' => null,
+        ]);
+    }
+}

--- a/app/Filament/Resources/Batches/Pages/ViewBatch.php
+++ b/app/Filament/Resources/Batches/Pages/ViewBatch.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Batches\Pages;
 use App\Actions\Batch\AcceptModificationRequestBatchAction;
 use App\Actions\Batch\DownloadBatchAttachmentsAction;
 use App\Actions\Batch\RequestModificationBatchAction;
+use App\Actions\Batch\RevertBatchToPendingAction;
 use App\Actions\FinalizeBatchAction;
 use App\Enums\ApplicationStatus;
 use App\Enums\BatchStatus;
@@ -17,6 +18,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use InvalidArgumentException;
 
 class ViewBatch extends ViewRecord
@@ -102,6 +104,35 @@ class ViewBatch extends ViewRecord
                         $admin->notify(new \App\Notifications\BatchFinalizedNotification($this->record));
                     }
                     $this->refreshFormData(['status']);
+                }),
+            Action::make('revert_to_pending')
+                ->label('Revert to Pending')
+                ->icon('heroicon-o-arrow-uturn-left')
+                ->color('warning')
+                ->requiresConfirmation()
+                ->modalHeading('Revert batch to pending?')
+                ->modalDescription('The batch will return to pending status and the representative can edit it again. Application workflow status will be cleared.')
+                ->visible(fn (): bool => Gate::allows('revertToPending', $this->record))
+                ->action(function (): void {
+                    Gate::authorize('revertToPending', $this->record);
+
+                    try {
+                        app(RevertBatchToPendingAction::class)->execute($this->record);
+                    } catch (InvalidArgumentException $exception) {
+                        Notification::make()
+                            ->title($exception->getMessage())
+                            ->danger()
+                            ->send();
+
+                        return;
+                    }
+
+                    $this->refreshFormData(['status', 'application_status']);
+
+                    Notification::make()
+                        ->title('Batch reverted to pending.')
+                        ->success()
+                        ->send();
                 }),
             Action::make('mark_for_submission')
                 ->label('Mark as For Submission')

--- a/app/Filament/Resources/FormSubmissions/Concerns/HasBatchAssignmentActions.php
+++ b/app/Filament/Resources/FormSubmissions/Concerns/HasBatchAssignmentActions.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Filament\Resources\FormSubmissions\Concerns;
+
+use App\Actions\Batch\AssignBatchAction;
+use App\Actions\Batch\UnAssignBatchAction;
+use App\Enums\BatchStatus;
+use App\Enums\UserRole;
+use App\Filament\Resources\Batches\BatchResource;
+use App\Filament\Resources\FormSubmissions\FormSubmissionResource;
+use App\Models\Batch;
+use App\Models\FormSubmission;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+
+trait HasBatchAssignmentActions
+{
+    protected function makeAssignBatchAction(): Action
+    {
+        return Action::make('assign_batch')
+            ->label(fn (): string => $this->record->batch_id === null ? 'Assign to Batch' : 'Reassign to Batch')
+            ->icon('heroicon-o-archive-box-arrow-down')
+            ->color('info')
+            ->visible(fn (): bool => Gate::allows('assignBatch', $this->record))
+            ->modalSubmitActionLabel(fn (): string => $this->record->batch_id === null ? 'Assign' : 'Reassign')
+            ->form([
+                Select::make('batch_id')
+                    ->label('Batch')
+                    ->options(fn (): array => $this->getBatchOptionsForAssignment())
+                    ->required()
+                    ->searchable()
+                    ->default(fn (): ?string => $this->record->batch_id),
+            ])
+            ->action(function (array $data): void {
+                Gate::authorize('assignBatch', $this->record);
+
+                $batch = Batch::findOrFail($data['batch_id']);
+
+                if ($batch->office_id !== $this->record->office_id) {
+                    Notification::make()
+                        ->title('The selected batch belongs to a different office.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                if (Auth::user()?->role !== UserRole::ADMIN->value && $batch->status === BatchStatus::FINALIZED) {
+                    Notification::make()
+                        ->title('Cannot assign to a finalized batch.')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $isReassign = $this->record->batch_id !== null;
+
+                app(AssignBatchAction::class)->execute($this->record, $batch);
+
+                $this->record->refresh();
+
+                Notification::make()
+                    ->title($isReassign ? 'Batch reassigned.' : 'Batch assigned.')
+                    ->success()
+                    ->send();
+
+                if (Auth::user()?->role === UserRole::REPRESENTATIVE->value) {
+                    $this->redirect(FormSubmissionResource::getUrl('index'), navigate: true);
+
+                    return;
+                }
+
+                if (Auth::user()?->role === UserRole::ADMIN->value && $this->record->batch_id !== null) {
+                    $this->redirect(BatchResource::getUrl('view', ['record' => $this->record->batch_id]), navigate: true);
+
+                    return;
+                }
+
+                if (method_exists($this, 'refreshFormWithPersistedState')) {
+                    $this->refreshFormWithPersistedState();
+                }
+            });
+    }
+
+    protected function makeUnassignBatchAction(): Action
+    {
+        return Action::make('unassign_batch')
+            ->label('Remove from Batch')
+            ->icon('heroicon-o-archive-box-x-mark')
+            ->color('danger')
+            ->visible(fn (): bool => Gate::allows('unassignBatch', $this->record))
+            ->requiresConfirmation()
+            ->action(function (): void {
+                Gate::authorize('unassignBatch', $this->record);
+
+                app(UnAssignBatchAction::class)->execute($this->record);
+
+                $this->record->refresh();
+
+                Notification::make()
+                    ->title('Batch unassigned.')
+                    ->success()
+                    ->send();
+
+                if (method_exists($this, 'refreshFormWithPersistedState')) {
+                    $this->refreshFormWithPersistedState();
+                }
+            });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getBatchOptionsForAssignment(): array
+    {
+        /** @var FormSubmission $submission */
+        $submission = $this->record;
+
+        $query = Batch::query()
+            ->where('office_id', $submission->office_id)
+            ->orderBy('batch_name');
+
+        if (Auth::user()?->role !== UserRole::ADMIN->value) {
+            $query->where('status', '!=', BatchStatus::FINALIZED);
+        }
+
+        return $query->pluck('batch_name', 'id')->all();
+    }
+}

--- a/app/Filament/Resources/FormSubmissions/Pages/EditFormSubmission.php
+++ b/app/Filament/Resources/FormSubmissions/Pages/EditFormSubmission.php
@@ -2,24 +2,20 @@
 
 namespace App\Filament\Resources\FormSubmissions\Pages;
 
-use App\Actions\Batch\AssignBatchAction;
-use App\Actions\Batch\UnAssignBatchAction;
 use App\Actions\FormSubmission\FinalizeFormSubmissionAction;
-use App\Enums\BatchStatus;
 use App\Enums\FormSubmissionStatus;
 use App\Enums\UserRole;
 use App\Filament\Resources\Batches\BatchResource;
+use App\Filament\Resources\FormSubmissions\Concerns\HasBatchAssignmentActions;
 use App\Filament\Resources\FormSubmissions\FormSubmissionResource;
 use App\Filament\Support\PasswordConfirmation;
 use App\Models\Address;
 use App\Models\Attachment;
-use App\Models\Batch;
 use App\Models\FormSubmission;
 use App\Services\AttachmentPathService;
 use App\Services\AttachmentRuleService;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
-use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Support\Facades\Auth;
@@ -27,6 +23,8 @@ use Illuminate\Support\Facades\Storage;
 
 class EditFormSubmission extends EditRecord
 {
+    use HasBatchAssignmentActions;
+
     private ?string $originalFirstname = null;
 
     private ?string $originalLastname = null;
@@ -105,72 +103,8 @@ class EditFormSubmission extends EditRecord
 
                     $this->redirect(FormSubmissionResource::getUrl('view', ['record' => $this->record]));
                 }),
-            Action::make('assign_batch')
-                ->label('Assign to Batch')
-                ->icon('heroicon-o-archive-box-arrow-down')
-                ->color('info')
-                ->visible(fn () => in_array($this->record->status, [FormSubmissionStatus::FINALIZED, FormSubmissionStatus::NEEDS_REVISION], true)
-                    && $this->record->batch_id === null)
-                ->modalSubmitActionLabel('Assign')
-                ->form([
-                    Select::make('batch_id')
-                        ->label('Batch')
-                        ->options(
-                            Batch::query()
-                                ->where('office_id', $this->record->office_id)
-                                ->where('status', '!=', BatchStatus::FINALIZED)
-                                ->orderBy('batch_name')
-                                ->pluck('batch_name', 'id')
-                        )
-                        ->required()
-                        ->searchable()
-                        ->default(fn () => $this->record->batch_id),
-                ])
-                ->action(function (array $data) {
-                    $batch = Batch::findOrFail($data['batch_id']);
-
-                    if ($batch->status === BatchStatus::FINALIZED) {
-                        Notification::make()
-                            ->title('Cannot assign to a finalized batch.')
-                            ->danger()
-                            ->send();
-
-                        return;
-                    }
-
-                    app(AssignBatchAction::class)->execute($this->record, $batch);
-
-                    Notification::make()
-                        ->title('Batch assigned.')
-                        ->success()
-                        ->send();
-
-                    if (Auth::user()?->role === UserRole::REPRESENTATIVE->value) {
-                        $this->redirect(FormSubmissionResource::getUrl('index'), navigate: true);
-
-                        return;
-                    }
-
-                    $this->refreshFormWithPersistedState();
-                }),
-
-            Action::make('unassign_batch')
-                ->label('Remove from Batch')
-                ->icon('heroicon-o-archive-box-x-mark')
-                ->color('danger')
-                ->visible(fn (): bool => $this->record->batch_id !== null
-                    && $this->record->batch?->status !== BatchStatus::FINALIZED)
-                ->requiresConfirmation()
-                ->action(function () {
-                    app(UnAssignBatchAction::class)->execute($this->record);
-
-                    Notification::make()
-                        ->title('Batch unassigned.')
-                        ->success()
-                        ->send();
-
-                    $this->refreshFormWithPersistedState();
-                }),
+            $this->makeAssignBatchAction(),
+            $this->makeUnassignBatchAction(),
             DeleteAction::make()
                 ->schema(PasswordConfirmation::schema())
                 ->before(PasswordConfirmation::before()),

--- a/app/Filament/Resources/FormSubmissions/Pages/ViewFormSubmission.php
+++ b/app/Filament/Resources/FormSubmissions/Pages/ViewFormSubmission.php
@@ -2,8 +2,6 @@
 
 namespace App\Filament\Resources\FormSubmissions\Pages;
 
-use App\Actions\Batch\AssignBatchAction;
-use App\Actions\Batch\UnAssignBatchAction;
 use App\Actions\FormSubmission\FlagNeedsRevisionFormSubmissionAction;
 use App\Actions\FormSubmission\ForSubmissionAction;
 use App\Actions\FormSubmission\UnFinalizeFormSubmissionAction;
@@ -11,13 +9,12 @@ use App\Enums\BatchStatus;
 use App\Enums\FormSubmissionStatus;
 use App\Enums\UserRole;
 use App\Filament\Resources\Batches\BatchResource;
+use App\Filament\Resources\FormSubmissions\Concerns\HasBatchAssignmentActions;
 use App\Filament\Resources\FormSubmissions\FormSubmissionResource;
 use App\Models\Address;
-use App\Models\Batch;
 use App\Models\User;
 use App\Services\AttachmentRuleService;
 use Filament\Actions\Action;
-use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Support\Facades\Auth;
@@ -25,6 +22,8 @@ use Illuminate\Support\Facades\Gate;
 
 class ViewFormSubmission extends ViewRecord
 {
+    use HasBatchAssignmentActions;
+
     protected static string $resource = FormSubmissionResource::class;
 
     public function mount(int|string $record): void
@@ -206,60 +205,8 @@ class ViewFormSubmission extends ViewRecord
 
                     $this->refreshFormData(['flagged_by', 'flag_remarks']);
                 }),
-            Action::make('assign_batch')
-                ->label('Assign to Batch')
-                ->icon('heroicon-o-archive-box-arrow-down')
-                ->color('info')
-                ->visible(fn () => Auth::user()->role !== UserRole::ADMIN->value
-                    && in_array($this->record->status, [FormSubmissionStatus::FINALIZED, FormSubmissionStatus::NEEDS_REVISION], true)
-                    && $this->record->batch_id === null
-                    && $this->record->batch?->status !== BatchStatus::FINALIZED)
-                ->form([
-                    Select::make('batch_id')
-                        ->label('Batch')
-                        ->options(
-                            Batch::query()
-                                ->where('office_id', Auth::user()->office_id)
-                                ->where('status', '!=', BatchStatus::FINALIZED->value)
-                                ->orderBy('batch_name')
-                                ->pluck('batch_name', 'id')
-                        )
-                        ->required()
-                        ->searchable()
-                        ->default(fn () => $this->record->batch_id),
-                ])
-                ->action(function (array $data) {
-                    $batch = Batch::findOrFail($data['batch_id']);
-
-                    app(AssignBatchAction::class)->execute($this->record, $batch);
-
-                    Notification::make()
-                        ->title('Batch assigned.')
-                        ->success()
-                        ->send();
-
-                    if (Auth::user()?->role === UserRole::REPRESENTATIVE->value) {
-                        $this->redirect(FormSubmissionResource::getUrl('index'), navigate: true);
-
-                        return;
-                    }
-                }),
-            Action::make('unassign_batch')
-                ->label('Remove from Batch')
-                ->icon('heroicon-o-archive-box-x-mark')
-                ->color('danger')
-                ->visible(fn (): bool => Auth::user()->role !== UserRole::ADMIN->value
-                    && $this->record->batch_id !== null
-                    && $this->record->batch?->status !== BatchStatus::FINALIZED)
-                ->requiresConfirmation()
-                ->action(function () {
-                    app(UnAssignBatchAction::class)->execute($this->record);
-
-                    Notification::make()
-                        ->title('Batch unassigned.')
-                        ->success()
-                        ->send();
-                }),
+            $this->makeAssignBatchAction(),
+            $this->makeUnassignBatchAction(),
         ];
     }
 

--- a/app/Policies/BatchPolicy.php
+++ b/app/Policies/BatchPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\BatchStatus;
 use App\Enums\UserRole;
 use App\Models\Batch;
 use App\Models\User;
@@ -50,6 +51,18 @@ class BatchPolicy
     public function markForSubmission(User $user, Batch $batch): bool
     {
         return $user->role === UserRole::ADMIN->value;
+    }
+
+    /**
+     * Revert a finalized batch back to pending (admin only).
+     */
+    public function revertToPending(User $user, Batch $batch): bool
+    {
+        if ($user->role !== UserRole::ADMIN->value) {
+            return false;
+        }
+
+        return $batch->status === BatchStatus::FINALIZED;
     }
 
     /**

--- a/app/Policies/FormSubmissionPolicy.php
+++ b/app/Policies/FormSubmissionPolicy.php
@@ -51,6 +51,68 @@ class FormSubmissionPolicy
     }
 
     /**
+     * Assign or reassign a submission to a batch (admins may target any batch status).
+     */
+    public function assignBatch(User $user, FormSubmission $formSubmission): bool
+    {
+        if (! in_array($formSubmission->status, [
+            FormSubmissionStatus::FINALIZED,
+            FormSubmissionStatus::NEEDS_REVISION,
+            FormSubmissionStatus::FOR_SUBMISSION,
+        ], true)) {
+            return false;
+        }
+
+        if ($user->role === UserRole::ADMIN->value) {
+            return true;
+        }
+
+        if ($user->role === UserRole::REPRESENTATIVE->value) {
+            if ($formSubmission->office_id !== $user->office_id) {
+                return false;
+            }
+
+            return $formSubmission->batch_id === null;
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove a submission from its batch (admins may unassign from finalized batches).
+     */
+    public function unassignBatch(User $user, FormSubmission $formSubmission): bool
+    {
+        if ($formSubmission->batch_id === null) {
+            return false;
+        }
+
+        if (! in_array($formSubmission->status, [
+            FormSubmissionStatus::FINALIZED,
+            FormSubmissionStatus::NEEDS_REVISION,
+            FormSubmissionStatus::FOR_SUBMISSION,
+        ], true)) {
+            return false;
+        }
+
+        if ($user->role === UserRole::ADMIN->value) {
+            return true;
+        }
+
+        if ($user->role === UserRole::REPRESENTATIVE->value) {
+            if ($formSubmission->office_id !== $user->office_id) {
+                return false;
+            }
+
+            $formSubmission->loadMissing('batch');
+
+            return $formSubmission->batch?->status !== BatchStatus::FINALIZED;
+        }
+
+        return false;
+    }
+
+    /**
      * Mark a finalized submission as For Submission (admin only, parent batch must be finalized).
      */
     public function markForSubmission(User $user, FormSubmission $formSubmission): bool

--- a/tests/Feature/FormSubmissionBatchAssignmentPolicyTest.php
+++ b/tests/Feature/FormSubmissionBatchAssignmentPolicyTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Enums\BatchStatus;
+use App\Enums\FormSubmissionStatus;
+use App\Enums\UserRole;
+use App\Models\Batch;
+use App\Models\FormSubmission;
+use App\Models\User;
+use App\Policies\FormSubmissionPolicy;
+
+beforeEach(function (): void {
+    $this->policy = new FormSubmissionPolicy;
+});
+
+it('allows admins to assign finalized submissions that already belong to a batch', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $submission = FormSubmission::make([
+        'status' => FormSubmissionStatus::FINALIZED,
+        'office_id' => 'office-1',
+        'batch_id' => 'batch-1',
+    ]);
+
+    expect($this->policy->assignBatch($admin, $submission))->toBeTrue();
+});
+
+it('allows admins to unassign submissions from finalized batches', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = Batch::make([
+        'status' => BatchStatus::FINALIZED,
+        'office_id' => 'office-1',
+    ]);
+
+    $submission = FormSubmission::make([
+        'status' => FormSubmissionStatus::FOR_SUBMISSION,
+        'office_id' => 'office-1',
+        'batch_id' => 'batch-1',
+    ]);
+    $submission->setRelation('batch', $batch);
+
+    expect($this->policy->unassignBatch($admin, $submission))->toBeTrue();
+});
+
+it('prevents representatives from assigning submissions that already belong to a batch', function (): void {
+    $representative = User::make([
+        'role' => UserRole::REPRESENTATIVE->value,
+        'office_id' => 'office-1',
+    ]);
+
+    $submission = FormSubmission::make([
+        'status' => FormSubmissionStatus::FINALIZED,
+        'office_id' => 'office-1',
+        'batch_id' => 'batch-1',
+    ]);
+
+    expect($this->policy->assignBatch($representative, $submission))->toBeFalse();
+});
+
+it('prevents representatives from unassigning submissions in finalized batches', function (): void {
+    $representative = User::make([
+        'role' => UserRole::REPRESENTATIVE->value,
+        'office_id' => 'office-1',
+    ]);
+
+    $batch = Batch::make([
+        'status' => BatchStatus::FINALIZED,
+        'office_id' => 'office-1',
+    ]);
+
+    $submission = FormSubmission::make([
+        'status' => FormSubmissionStatus::FINALIZED,
+        'office_id' => 'office-1',
+        'batch_id' => 'batch-1',
+    ]);
+    $submission->setRelation('batch', $batch);
+
+    expect($this->policy->unassignBatch($representative, $submission))->toBeFalse();
+});

--- a/tests/Feature/RevertBatchToPendingTest.php
+++ b/tests/Feature/RevertBatchToPendingTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Actions\Batch\RevertBatchToPendingAction;
+use App\Enums\ApplicationStatus;
+use App\Enums\BatchStatus;
+use App\Enums\UserRole;
+use App\Models\Batch;
+use App\Models\User;
+use App\Policies\BatchPolicy;
+
+beforeEach(function (): void {
+    $this->policy = new BatchPolicy;
+    $this->action = new RevertBatchToPendingAction;
+});
+
+it('allows admins to revert finalized batches to pending', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = Batch::make([
+        'status' => BatchStatus::FINALIZED,
+        'application_status' => ApplicationStatus::PENDING_FOR_REVIEW,
+    ]);
+
+    expect($this->policy->revertToPending($admin, $batch))->toBeTrue();
+});
+
+it('prevents non-admins from reverting batches to pending', function (): void {
+    $representative = User::make(['role' => UserRole::REPRESENTATIVE->value]);
+
+    $batch = Batch::make(['status' => BatchStatus::FINALIZED]);
+
+    expect($this->policy->revertToPending($representative, $batch))->toBeFalse();
+});
+
+it('throws when reverting a batch that is not finalized', function (): void {
+    $batch = Batch::make(['status' => BatchStatus::PENDING]);
+
+    $this->action->execute($batch);
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
- Updated AssignBatchAction to include office ID validation and actor role checks, preventing assignment to finalized batches unless the user is an admin.
- Added a new action in ViewBatch to revert finalized batches to pending status, with appropriate authorization checks.
- Refactored batch assignment actions in EditFormSubmission and ViewFormSubmission to utilize shared methods for better code organization.
- Introduced new policies for batch assignment and unassignment, ensuring proper role-based access control for users.