### PR TITLE
Enhance batch finalization and deletion permissions

### DIFF
--- a/app/Filament/Resources/Batches/Pages/ViewBatch.php
+++ b/app/Filament/Resources/Batches/Pages/ViewBatch.php
@@ -14,6 +14,7 @@ use App\Enums\UserRole;
 use App\Filament\Resources\Batches\BatchResource;
 use App\Notifications\BatchNeedsRevisionNotification;
 use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\Support\Htmlable;
@@ -86,9 +87,10 @@ class ViewBatch extends ViewRecord
 
                     return null;
                 })
-                ->hidden(fn () => $this->record->status === BatchStatus::FINALIZED
-                        || Auth::user()?->role !== UserRole::REPRESENTATIVE->value)
-                ->action(function () {
+                ->visible(fn (): bool => Gate::allows('finalize', $this->record))
+                ->action(function (): void {
+                    Gate::authorize('finalize', $this->record);
+
                     if ($this->hasNeedsRevisionSubmissions()) {
                         Notification::make()
                             ->title('You cannot finalize while there are submissions that need revision')
@@ -105,6 +107,8 @@ class ViewBatch extends ViewRecord
                     }
                     $this->refreshFormData(['status']);
                 }),
+            DeleteAction::make()
+                ->successRedirectUrl(BatchResource::getUrl('index')),
             Action::make('revert_to_pending')
                 ->label('Revert to Pending')
                 ->icon('heroicon-o-arrow-uturn-left')

--- a/app/Policies/BatchPolicy.php
+++ b/app/Policies/BatchPolicy.php
@@ -54,6 +54,26 @@ class BatchPolicy
     }
 
     /**
+     * Finalize a batch (admin or owning-office representative).
+     */
+    public function finalize(User $user, Batch $batch): bool
+    {
+        if ($batch->status === BatchStatus::FINALIZED) {
+            return false;
+        }
+
+        if ($user->role === UserRole::ADMIN->value) {
+            return true;
+        }
+
+        if ($user->role === UserRole::REPRESENTATIVE->value) {
+            return $user->office_id === $batch->office_id;
+        }
+
+        return false;
+    }
+
+    /**
      * Revert a finalized batch back to pending (admin only).
      */
     public function revertToPending(User $user, Batch $batch): bool
@@ -70,7 +90,11 @@ class BatchPolicy
      */
     public function delete(User $user, Batch $batch): bool
     {
-        return false;
+        if ($user->role !== UserRole::ADMIN->value) {
+            return false;
+        }
+
+        return ! $batch->formSubmissions()->exists();
     }
 
     /**

--- a/tests/Feature/BatchPolicyTest.php
+++ b/tests/Feature/BatchPolicyTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Enums\BatchStatus;
+use App\Enums\UserRole;
+use App\Models\Batch;
+use App\Models\User;
+use App\Policies\BatchPolicy;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+beforeEach(function (): void {
+    $this->policy = new BatchPolicy;
+});
+
+it('allows admins to finalize non-finalized batches', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = Batch::make(['status' => BatchStatus::PENDING]);
+
+    expect($this->policy->finalize($admin, $batch))->toBeTrue();
+});
+
+it('allows representatives to finalize batches in their office', function (): void {
+    $representative = User::make([
+        'role' => UserRole::REPRESENTATIVE->value,
+        'office_id' => 'office-1',
+    ]);
+
+    $batch = Batch::make([
+        'status' => BatchStatus::PENDING,
+        'office_id' => 'office-1',
+    ]);
+
+    expect($this->policy->finalize($representative, $batch))->toBeTrue();
+});
+
+it('prevents finalizing already finalized batches', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = Batch::make(['status' => BatchStatus::FINALIZED]);
+
+    expect($this->policy->finalize($admin, $batch))->toBeFalse();
+});
+
+it('allows admins to delete batches with no submissions', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = new class extends Batch
+    {
+        public function formSubmissions(): HasMany
+        {
+            $relation = Mockery::mock(HasMany::class);
+            $relation->shouldReceive('exists')->andReturn(false);
+
+            return $relation;
+        }
+    };
+
+    expect($this->policy->delete($admin, $batch))->toBeTrue();
+});
+
+it('prevents deleting batches that still have submissions', function (): void {
+    $admin = User::make(['role' => UserRole::ADMIN->value]);
+
+    $batch = new class extends Batch
+    {
+        public function formSubmissions(): HasMany
+        {
+            $relation = Mockery::mock(HasMany::class);
+            $relation->shouldReceive('exists')->andReturn(true);
+
+            return $relation;
+        }
+    };
+
+    expect($this->policy->delete($admin, $batch))->toBeFalse();
+});
+
+it('prevents non-admins from deleting batches', function (): void {
+    $representative = User::make(['role' => UserRole::REPRESENTATIVE->value]);
+
+    $batch = Batch::make(['status' => BatchStatus::PENDING]);
+
+    expect($this->policy->delete($representative, $batch))->toBeFalse();
+});


### PR DESCRIPTION
- Added a new policy method to authorize batch finalization for admins and office representatives.
- Updated ViewBatch page to include a delete action with a success redirect, ensuring proper user permissions are enforced.
- Improved visibility of the finalize action based on user roles and batch status, enhancing security and user experience.