### PR TITLE
Refactor visibility logic for form submission actions

### DIFF
--- a/app/Filament/Resources/Batches/RelationManagers/FormSubmissionsRelationManager.php
+++ b/app/Filament/Resources/Batches/RelationManagers/FormSubmissionsRelationManager.php
@@ -58,17 +58,7 @@ class FormSubmissionsRelationManager extends RelationManager
                     return null;
                 }
 
-                if ($record->status === FormSubmissionStatus::NEEDS_REVISION) {
-                    if (
-                        Auth::user()?->role === UserRole::REPRESENTATIVE->value
-                        && $this->ownerRecord->status !== BatchStatus::NEEDS_REVISION->value
-                    ) {
-                        return FormSubmissionResource::getUrl('view', [
-                            'record' => $record,
-                            'batch' => $this->ownerRecord->getKey(),
-                        ]);
-                    }
-
+                if (Gate::allows('update', $record)) {
                     return FormSubmissionResource::getUrl('edit', [
                         'record' => $record,
                         'batch' => $this->ownerRecord->getKey(),
@@ -94,15 +84,13 @@ class FormSubmissionsRelationManager extends RelationManager
                             'record' => $record,
                             'batch' => $this->ownerRecord->getKey(),
                         ]))
-                        ->visible(fn ($record) => $this->ownerRecord->status === BatchStatus::NEEDS_REVISION
-                            && $record->status === FormSubmissionStatus::NEEDS_REVISION
-                            && Gate::allows('update', $record)),
+                        ->visible(fn ($record) => Gate::allows('update', $record)),
                     ViewAction::make()
                         ->url(fn ($record) => FormSubmissionResource::getUrl('view', [
                             'record' => $record,
                             'batch' => $this->ownerRecord->getKey(),
                         ]))
-                        ->visible(fn ($record) => in_array($record->status, [FormSubmissionStatus::FINALIZED, FormSubmissionStatus::FOR_SUBMISSION, FormSubmissionStatus::APPROVED_SUBMISSION, FormSubmissionStatus::NEEDS_REVISION])),
+                        ->visible(fn ($record) => ! Gate::allows('update', $record)),
                 ],
             )
             ->toolbarActions($toolbarActions);

--- a/tests/Feature/BatchViewSubmissionAccessTest.php
+++ b/tests/Feature/BatchViewSubmissionAccessTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Enums\BatchStatus;
+use App\Enums\FormSubmissionStatus;
+use App\Enums\Sex;
+use App\Enums\UserRole;
+use App\Filament\Resources\Batches\Pages\ViewBatch;
+use App\Filament\Resources\Batches\RelationManagers\FormSubmissionsRelationManager;
+use App\Filament\Resources\FormSubmissions\FormSubmissionResource;
+use App\Models\Batch;
+use App\Models\FormSubmission;
+use App\Models\Office;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+function createBatchSubmission(Office $office, Batch $batch, FormSubmissionStatus $status): FormSubmission
+{
+    return FormSubmission::query()->create([
+        'firstname' => fake()->firstName(),
+        'lastname' => fake()->lastName(),
+        'email' => fake()->unique()->safeEmail(),
+        'phone_number' => '09'.fake()->numerify('#########'),
+        'office_id' => $office->id,
+        'batch_id' => $batch->id,
+        'organizational_unit' => 'Unit A',
+        'civil_status' => 'single',
+        'status' => $status->value,
+        'sex' => Sex::Male->value,
+        'tin_number' => fake()->numerify('#########'),
+        'birth_date' => fake()->unique()->date(),
+    ]);
+}
+
+it('lets representatives open pending submissions in edit mode from a reverted batch', function (): void {
+    $office = Office::query()->create([
+        'name' => 'Davao Del Sur',
+        'acronym' => 'DDS',
+        'number_of_employees' => 10,
+    ]);
+
+    $representative = User::factory()->create([
+        'role' => UserRole::REPRESENTATIVE->value,
+        'office_id' => $office->id,
+    ]);
+
+    $batch = Batch::query()->create([
+        'office_id' => $office->id,
+        'user_id' => $representative->id,
+        'batch_name' => 'DDS-1',
+        'status' => BatchStatus::PENDING->value,
+        'application_status' => null,
+    ]);
+
+    $submission = createBatchSubmission($office, $batch, FormSubmissionStatus::PENDING);
+
+    $this->actingAs($representative);
+
+    Livewire::test(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $batch,
+        'pageClass' => ViewBatch::class,
+    ])
+        ->assertSuccessful()
+        ->loadTable()
+        ->assertCanSeeTableRecords([$submission])
+        ->assertTableActionVisible('edit', $submission->getKey())
+        ->assertTableActionHasUrl('edit', FormSubmissionResource::getUrl('edit', [
+            'record' => $submission,
+            'batch' => $batch->getKey(),
+        ]), $submission->getKey())
+        ->assertTableActionHidden('view', $submission->getKey());
+});
+
+it('keeps finalized submissions view only from the batch page', function (): void {
+    $office = Office::query()->create([
+        'name' => 'Davao Del Norte',
+        'acronym' => 'DDN',
+        'number_of_employees' => 12,
+    ]);
+
+    $representative = User::factory()->create([
+        'role' => UserRole::REPRESENTATIVE->value,
+        'office_id' => $office->id,
+    ]);
+
+    $batch = Batch::query()->create([
+        'office_id' => $office->id,
+        'user_id' => $representative->id,
+        'batch_name' => 'DDN-1',
+        'status' => BatchStatus::FINALIZED->value,
+        'application_status' => null,
+    ]);
+
+    $submission = createBatchSubmission($office, $batch, FormSubmissionStatus::FINALIZED);
+
+    $this->actingAs($representative);
+
+    Livewire::test(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $batch,
+        'pageClass' => ViewBatch::class,
+    ])
+        ->assertSuccessful()
+        ->loadTable()
+        ->assertCanSeeTableRecords([$submission])
+        ->assertTableActionVisible('view', $submission->getKey())
+        ->assertTableActionHasUrl('view', FormSubmissionResource::getUrl('view', [
+            'record' => $submission,
+            'batch' => $batch->getKey(),
+        ]), $submission->getKey())
+        ->assertTableActionHidden('edit', $submission->getKey());
+});


### PR DESCRIPTION
- Updated the visibility conditions for edit and view actions in the FormSubmissionsRelationManager.
- Simplified the logic to use Gate::allows for determining user permissions, enhancing clarity and maintainability.
- Removed specific status checks related to revision needs, streamlining the user experience for authorized users.